### PR TITLE
fix: extends React.Component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 
-export default class PieChart {
+export default class PieChart extends React.Component {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape({
       value: PropTypes.number,


### PR DESCRIPTION
thanks for that handy lib :)

fix for react 0.15 : "extends React.Component" is now mandatory

https://github.com/facebook/react/issues/5355#issuecomment-153207296
