### PR TITLE
import prop-types separately

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react"
+import React, {Component} from "react"
+import PropTypes from "prop-types"
 
 class PieChart extends Component {
   handleSectorHover(i) {


### PR DESCRIPTION
With react 15.5.4 I'm getting:

    warning.js:36 Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

I think this should fix it...