### PR TITLE
Added hyperlinkMethod prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,18 @@ const MyCompo = () => (
 
 ### Props
 
-| Name                     | PropType              | Description                                                                                                  | Default                               |
-| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
-| data                     | Array of data Objects | One data is {value: number (required), color: string, title: string, expanded: bool}                         | []                                    |
-| expandOnHover            | Boolean               | Active hover and touch (mobile) effetcs                                                                      | false                                 |
-| onSectorHover            | Function              | Callback when one sector is hovered or touched (mobile) - ex: `(data, index, event) => {}`                   | null                                  |
+| Name                     | PropType              | Description                                                                                                  | Default    |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ | ---------- |
+| data                     | Array of data Objects | One data is {value: number (required), color: string, title: string, expanded: bool, href: string}           | []         |
+| expandOnHover            | Boolean               | Active hover and touch (mobile) effects                                                                      | false      |
+| onSectorHover            | Function              | Callback when one sector is hovered or touched (mobile) - ex: `(data, index, event) => {}`                   | null       |
 | expandSize               | Number                | expand size, in pixels. Used if `expandOnHover` is active or one data has `expanded` attribute set to `true` |
-| strokeColor              | String                | Sector stroke color                                                                                          | "#fff"                                |
-| strokeLinejoin           | String                | Sector stroke line join (One of `miter`, `round`, `bevel`)                                                   | "round"                               |
-| strokeWidth              | Number                | Sector width, in pixels (0 to disable stroke)                                                                | 1                                     |
-| viewBoxSize              | Number                | SVG viewbox width and height                                                                                 | 100                                   |
-| transitionDuration       | String                | CSS property for transition-duration, set to `0s` to disable transition                                      | "0s"                                  |
-| transitionTimingFunction | String                | CSS Property for transition-timing-function                                                                  | "ease-out"                            |
-| hyperlinkMethod          | Function or Boolean   | Provide a function to generate an href, it is passed a data object containing the section title.             | data => return '/route/' + data.title |
+| strokeColor              | String                | Sector stroke color                                                                                          | "#fff"     |
+| strokeLinejoin           | String                | Sector stroke line join (One of `miter`, `round`, `bevel`)                                                   | "round"    |
+| strokeWidth              | Number                | Sector width, in pixels (0 to disable stroke)                                                                | 1          |
+| viewBoxSize              | Number                | SVG viewbox width and height                                                                                 | 100        |
+| transitionDuration       | String                | CSS property for transition-duration, set to `0s` to disable transition                                      | "0s"       |
+| transitionTimingFunction | String                | CSS Property for transition-timing-function                                                                  | "ease-out" |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,19 @@ const MyCompo = () => (
 
 ### Props
 
-| Name                     | PropType              | Description                                                                                                  | Default    |
-| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ | ---------- |
-| data                     | Array of data Objects | One data is {value: number (required), color: string, title: string, expanded: bool}                         | []         |
-| expandOnHover            | Boolean               | Active hover and touch (mobile) effetcs                                                                      | false      |
-| onSectorHover            | Function              | Callback when one sector is hovered or touched (mobile) - ex: `(data, index, event) => {}`                   | null       |
+| Name                     | PropType              | Description                                                                                                  | Default                               |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| data                     | Array of data Objects | One data is {value: number (required), color: string, title: string, expanded: bool}                         | []                                    |
+| expandOnHover            | Boolean               | Active hover and touch (mobile) effetcs                                                                      | false                                 |
+| onSectorHover            | Function              | Callback when one sector is hovered or touched (mobile) - ex: `(data, index, event) => {}`                   | null                                  |
 | expandSize               | Number                | expand size, in pixels. Used if `expandOnHover` is active or one data has `expanded` attribute set to `true` |
-| strokeColor              | String                | Sector stroke color                                                                                          | "#fff"     |
-| strokeLinejoin           | String                | Sector stroke line join (One of `miter`, `round`, `bevel`)                                                   | "round"    |
-| strokeWidth              | Number                | Sector width, in pixels (0 to disable stroke)                                                                | 1          |
-| viewBoxSize              | Number                | SVG viewbox width and height                                                                                 | 100        |
-| transitionDuration       | String                | CSS property for transition-duration, set to `0s` to disable transition                                      | "0s"       |
-| transitionTimingFunction | String                | CSS Property for transition-timing-function                                                                  | "ease-out" |
+| strokeColor              | String                | Sector stroke color                                                                                          | "#fff"                                |
+| strokeLinejoin           | String                | Sector stroke line join (One of `miter`, `round`, `bevel`)                                                   | "round"                               |
+| strokeWidth              | Number                | Sector width, in pixels (0 to disable stroke)                                                                | 1                                     |
+| viewBoxSize              | Number                | SVG viewbox width and height                                                                                 | 100                                   |
+| transitionDuration       | String                | CSS property for transition-duration, set to `0s` to disable transition                                      | "0s"                                  |
+| transitionTimingFunction | String                | CSS Property for transition-timing-function                                                                  | "ease-out"                            |
+| hyperlinkMethod          | Function or Boolean   | Provide a function to generate an href, it is passed a data object containing the section title.             | data => return '/route/' + data.title |
 
 ## Contributing
 

--- a/src/Sector/index.js
+++ b/src/Sector/index.js
@@ -12,9 +12,9 @@ const Sector = ({
   onMouseLeave,
   path,
   title,
+  href,
   transitionDuration,
   transitionTimingFunction,
-  hyperlinkMethod,
 }) => {
   let result
 
@@ -39,16 +39,8 @@ const Sector = ({
     </path>
   )
 
-  if (hyperlinkMethod) {
-    result = (
-      <a
-        xlinkHref={hyperlinkMethod({
-          title,
-        })}
-      >
-        {content}
-      </a>
-    )
+  if (href) {
+    result = <a href={href}>{content}</a>
   } else {
     result = content
   }
@@ -67,9 +59,9 @@ Sector.propTypes = {
   strokeLinejoin: PropTypes.string,
   strokeWidth: PropTypes.number,
   title: PropTypes.string,
+  href: PropTypes.string,
   transitionDuration: PropTypes.string,
   transitionTimingFunction: PropTypes.string,
-  hyperlinkMethod: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 }
 
 Sector.defaultProps = {
@@ -77,9 +69,9 @@ Sector.defaultProps = {
   strokeWidth: 1,
   strokeLinejoin: "round",
   title: null,
+  href: null,
   transitionDuration: "0s",
   transitionTimingFunction: "ease-out",
-  hyperlinkMethod: false,
 }
 
 export default Sector

--- a/src/Sector/index.js
+++ b/src/Sector/index.js
@@ -14,8 +14,11 @@ const Sector = ({
   title,
   transitionDuration,
   transitionTimingFunction,
+  hyperlinkMethod,
 }) => {
-  return (
+  let result
+
+  const content = (
     <path
       d={path}
       fill={fill}
@@ -35,6 +38,22 @@ const Sector = ({
       {title && <title>{title}</title>}
     </path>
   )
+
+  if (hyperlinkMethod) {
+    result = (
+      <a
+        xlinkHref={hyperlinkMethod({
+          title,
+        })}
+      >
+        {content}
+      </a>
+    )
+  } else {
+    result = content
+  }
+
+  return result
 }
 
 Sector.propTypes = {
@@ -50,6 +69,7 @@ Sector.propTypes = {
   title: PropTypes.string,
   transitionDuration: PropTypes.string,
   transitionTimingFunction: PropTypes.string,
+  hyperlinkMethod: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 }
 
 Sector.defaultProps = {
@@ -59,6 +79,7 @@ Sector.defaultProps = {
   title: null,
   transitionDuration: "0s",
   transitionTimingFunction: "ease-out",
+  hyperlinkMethod: false,
 }
 
 export default Sector

--- a/src/Sectors/index.js
+++ b/src/Sectors/index.js
@@ -22,16 +22,16 @@ const Sectors = ({
     <g>
       {data.map((d, i) => {
         const isLarge = d.value / total > 0.5
-        const angle = 360 * d.value / total
+        const angle = (360 * d.value) / total
         const radius = center + (d.expanded ? expandSize : 0) - strokeWidth / 2
 
         angleStart = angleEnd
         angleEnd = angleStart + angle
 
-        const x1 = center + radius * Math.cos(Math.PI * angleStart / 180)
-        const y1 = center + radius * Math.sin(Math.PI * angleStart / 180)
-        const x2 = center + radius * Math.cos(Math.PI * angleEnd / 180)
-        const y2 = center + radius * Math.sin(Math.PI * angleEnd / 180)
+        const x1 = center + radius * Math.cos((Math.PI * angleStart) / 180)
+        const y1 = center + radius * Math.sin((Math.PI * angleStart) / 180)
+        const x2 = center + radius * Math.cos((Math.PI * angleEnd) / 180)
+        const y2 = center + radius * Math.sin((Math.PI * angleEnd) / 180)
         const path = `
           M${center},${center}
           L${x1},${y1}
@@ -46,6 +46,7 @@ const Sectors = ({
             key={"sector" + i}
             fill={d.color}
             path={path}
+            href={d.href}
             strokeColor={strokeColor}
             strokeWidth={strokeWidth}
             total={total}

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,7 @@ PieChart.propTypes = {
   viewBoxSize: PropTypes.number,
   transitionDuration: Sector.propTypes.transitionDuration,
   transitionTimingFunction: Sector.propTypes.transitionTimingFunction,
+  hyperlinkMethod: Sector.propTypes.hyperlinkMethod,
 }
 
 PieChart.defaultProps = {
@@ -117,6 +118,7 @@ PieChart.defaultProps = {
   viewBoxSize: 100,
   transitionDuration: Sector.defaultProps.transitionDuration,
   transitionTimingFunction: Sector.defaultProps.transitionTimingFunction,
+  hyperlinkMethod: Sector.defaultProps.hyperlinkMethod,
 }
 
 export default PieChart

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ PieChart.propTypes = {
       color: PropTypes.string.isRequired,
       title: PropTypes.string,
       value: PropTypes.number.isRequired,
+      href: PropTypes.string,
     })
   ).isRequired,
   expandOnHover: PropTypes.bool,
@@ -103,7 +104,6 @@ PieChart.propTypes = {
   viewBoxSize: PropTypes.number,
   transitionDuration: Sector.propTypes.transitionDuration,
   transitionTimingFunction: Sector.propTypes.transitionTimingFunction,
-  hyperlinkMethod: Sector.propTypes.hyperlinkMethod,
 }
 
 PieChart.defaultProps = {
@@ -118,7 +118,6 @@ PieChart.defaultProps = {
   viewBoxSize: 100,
   transitionDuration: Sector.defaultProps.transitionDuration,
   transitionTimingFunction: Sector.defaultProps.transitionTimingFunction,
-  hyperlinkMethod: Sector.defaultProps.hyperlinkMethod,
 }
 
 export default PieChart


### PR DESCRIPTION
`hyperlinkMethod` prop allows you to generate an `xlink:href` attribute for each sector of the piechart. Currently it passes a data object with a title property, more properties could be added as needed.

The new code creates some uncovered lines in the test results, I'm not very familiar with writing tests otherwise I would cover this.